### PR TITLE
Update dlhandler_unix.cpp

### DIFF
--- a/src/dlhandler_unix.cpp
+++ b/src/dlhandler_unix.cpp
@@ -153,7 +153,7 @@ int DLHandler::findFiles (std::vector<std::string>& file_list,
 bool DLHandler :: openLib(const string& lib_name)
 {
 
-    if(LoadLibrary(lib_name.c_str()))
+    if(LoadLibrary(TEXT(lib_name.c_str())))
         return true;
 
     unsigned long err = GetLastError();


### PR DESCRIPTION
Fix suggested after discussion in issue [#1591](https://github.com/openbabel/openbabel/issues/1591).

`lib_name.c_str()` alwarys returns a `const char*` (C string).
The definition of `LoadLibrary()` changes depending on whether the macro `UNICODE` is defined or not (see `winbase.h`). In the former case, the `LoadLibrary()` is actually replaced by `LoadLibraryW()` which accepts `LPCWSTR {aka const wchar_t*}` type, and the compilation fails due to mismatching data type and non-implicit conversion. In the latter, `LoadLibraryA()` is called. That version works with `char*`.

The best solution seems to be the one detailed in the following article:
[](http://www.cplusplus.com/forum/articles/16820/)
the WinAPI provides the macros `TEXT()`, `_T()` and `T()` which do the same thing: convert `char*` to `LPCWSTR` and vice versa depending on the definition (or non-definition) of the `UNICODE` macro.